### PR TITLE
lowercase j in Javascript links to js files is now uppercase

### DIFF
--- a/index.html
+++ b/index.html
@@ -337,8 +337,8 @@
     <!-- <script src="../node_modules/table-dragger/dist/table-dragger.min.js"></script> -->
 
     <!-- Custom JS -->
-    <script type="text/javascript" src="assets/javascript/renderTable.js"></script>
-    <script type="text/javascript" src="assets/javascript/firebaseLogin.js"></script>
+    <script type="text/javascript" src="assets/Javascript/renderTable.js"></script>
+    <script type="text/javascript" src="assets/Javascript/firebaseLogin.js"></script>
     <!-- <script type="text/javascript" src="assets/javascript/app.js"></script> -->
     <!-- <script type="text/javascript" src="assets/javascript/weather.js"></script> -->
 </body>


### PR DESCRIPTION
typo for links to javascript files